### PR TITLE
Ensure `slackLevels` is always set for older files

### DIFF
--- a/CopyPaste.cs
+++ b/CopyPaste.cs
@@ -2123,6 +2123,12 @@ namespace Oxide.Plugins
                                     ioOutput.slackLevels[i] = Convert.ToSingle(slackLevels[i]);
                                 }
                             }
+                            else
+                            {
+                                ioOutput.slackLevels = new float[ioOutput.linePoints.Count()];
+                                for (var i = 0; i < ioOutput.slackLevels.Count(); i++)
+                                    ioOutput.slackLevels[i] = 0f;
+                            }
 
                             if (output.ContainsKey("lineAnchors") && output["lineAnchors"] is List<object> lineAnchors)
                             {


### PR DESCRIPTION
Bases copied before wireslacking was added in need a `slackLevel` set for every `linePoint` or the client receives an RPC error when trying to disconnect a wire.

Fix provided by Lorenzo