### PR TITLE
Check if `version` key exists before accessing

### DIFF
--- a/CopyPaste.cs
+++ b/CopyPaste.cs
@@ -1119,7 +1119,7 @@ namespace Oxide.Plugins
             var quaternionRotation = Quaternion.Euler(eulerRotation);
             
             // Parse VersionNumber
-            var version = protocol["version"] as Dictionary<string, object>;
+            var version = protocol.ContainsKey("version") ? protocol["version"] as Dictionary<string, object> : null;
             
             VersionNumber vNumber = default;
             if (version != null)


### PR DESCRIPTION
Fixes issues with bases saved in Fortify where the version number was stripped out.

Fix provided by nivex