### PR TITLE
Mark dirty and update outputs immediately

### DIFF
--- a/CopyPaste.cs
+++ b/CopyPaste.cs
@@ -2188,8 +2188,10 @@ namespace Oxide.Plugins
                 }
             }
 
-            ioEntity.MarkDirtyForceUpdateOutputs();
+            ioEntity.MarkDirty();
+            ioEntity.UpdateOutputs();
             ioEntity.SendNetworkUpdate();
+            ioEntity.RefreshIndustrialPreventBuilding();
         }
 
         private void SetItemSubEntity(PasteData pasteData, Item item, ulong oldId)


### PR DESCRIPTION
- Resolves an issue where IO entities saved in an "on" state required immediate power to maintain that state (fixes Industrial Crafters not always pasting back on)
- Always refresh industrial prevent building