### PR TITLE
Add validity check for IO entities in connections

### DIFF
--- a/CopyPaste.cs
+++ b/CopyPaste.cs
@@ -2101,6 +2101,10 @@ namespace Oxide.Plugins
                         {
                             var ioOutput = ioEntity.outputs[index];
                             var ioEntity2 = ioConnection["entity"] as IOEntity;
+
+                            if (!ioEntity2.IsValid() || ioEntity2.IsDestroyed)
+                                continue;
+
                             var connectedToSlot = Convert.ToInt32( output["connectedToSlot"] );
                             var ioInput = ioEntity2.inputs[connectedToSlot];
 


### PR DESCRIPTION
Skip processing of IO entities that are invalid or destroyed. Fixes rare situations where invalid entities cause nearby IO entities to be destroyed before IO processing