### PR TITLE
Call EnableSaving(false), which also removes already spawned entities from the save list, instead of just setting the .enableSaving prop

### DIFF
--- a/CopyPaste.cs
+++ b/CopyPaste.cs
@@ -1419,7 +1419,7 @@ namespace Oxide.Plugins
 
             if (!pasteData.EnableSaving)
             {
-                entity.enableSaving = false;
+                entity.EnableSaving(false);
             }
 
             if (entity is ModularCar modularCar && data.TryGetValue("children", out var childrenObj))
@@ -3164,7 +3164,7 @@ namespace Oxide.Plugins
 
                 if (!pasteData.EnableSaving)
                 {
-                    slotEntity.enableSaving = false;
+                    slotEntity.EnableSaving(false);
                 }
 
                 slotEntity.Spawn();


### PR DESCRIPTION
This fixes warning messages were already spawned children did not get removed from the save list, such as:
```
Entity is NULL but is still in saveList - not destroyed properly? ak47u.entity
Entity is NULL but is still in saveList - not destroyed properly? electricfurnace.io
Entity is NULL but is still in saveList - not destroyed properly? weaponracklightdouble
Entity is NULL but is still in saveList - not destroyed properly? ak47u.entity
Entity is NULL but is still in saveList - not destroyed properly? electricfurnace.io
Entity is NULL but is still in saveList - not destroyed properly? electricfurnace.io
Entity is NULL but is still in saveList - not destroyed properly? ak47u.entity
Entity is NULL but is still in saveList - not destroyed properly? ak47u.entity
Entity is NULL but is still in saveList - not destroyed properly? ak47u.entity
```